### PR TITLE
Add tests for new feature of custom pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Calibre-web-test
 
 - Testing LDAP on Windows requires the installation of python-ldap in the tested environment, therefore you need the corresponding wheel, and you have to point to the file in config_test.py (variable LDAP_WHL)   
 
+- Installing wkhtmltopdf is required. See [install instructions](https://github.com/JazzCore/python-pdfkit/wiki/Installing-wkhtmltopdf).
+
 - SSL Files for testing will be automatically generated. A Tutorial for generating ssl files can be found here [https://www.golinuxcloud.com/create-certificate-authority-root-ca-linux](https://www.golinuxcloud.com/create-certificate-authority-root-ca-linux) and here [https://www.golinuxcloud.com/openssl-create-client-server-certificate](https://www.golinuxcloud.com/openssl-create-client-server-certificate)
 
 - Mitmporoxy for Windows is problematic, as several modules are no longer available for newer python versions, so download the mitmproxy source for version 6.02 and patch the setup file to accept cryptography 36.0 and zstandard>0.15. Afterwards install via pip from this source

--- a/test/helper_ui.py
+++ b/test/helper_ui.py
@@ -60,6 +60,7 @@ page['basic_config'] = {'check': (By.ID, "config_port"),
 page['view_config'] = {'check': (By.NAME, "submit"), 'click': [(By.ID, "top_admin"), (By.ID, "view_config")]}
 page['mail_server'] = {'check': (By.ID, "mail_server"), 'click': [(By.ID, "top_admin"), (By.ID, "admin_edit_email")]}
 page['user_list'] = {'check': (By.ID, "user_delete_selection"), 'click': [(By.ID, "top_admin"), (By.ID, "admin_user_table")]}
+page['pages_config'] = {'check': (By.ID, "new_page"), 'click': [(By.ID, "top_admin"), (By.ID, "list_pages")]}
 page['admin_setup'] = {'check': (By.ID, "admin_edit_email"), 'click': [(By.ID, "top_admin")]}
 page['user_setup'] = {'check': (By.ID, "kindle_mail"), 'click': [(By.ID, "top_user")]}
 page['create_shelf'] = {'check': (By.ID, "title"), 'click': [(By.ID, "nav_createshelf")]}

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -16,7 +16,7 @@ rarfile>=4.0
 
 #Running Updater Test
 flask>=2.0.0
-mitmproxy==6.0.2
+mitmproxy==8.0.0
 
 # For running tests on helper
 Babel>=2.6.0

--- a/test/test_custom_pages.py
+++ b/test/test_custom_pages.py
@@ -3,13 +3,13 @@
 
 
 from unittest import TestCase
-import os
 import time
+import psutil
 from unittest import skip
 from selenium.webdriver.common.by import By
 
 from helper_ui import ui_class
-from config_test import TEST_DB, CALIBRE_WEB_PATH
+from config_test import TEST_DB, BOOT_TIME, CALIBRE_WEB_PATH
 from helper_func import startup
 from helper_func import save_logfiles
 
@@ -21,8 +21,7 @@ class TestCustomPages(TestCase, ui_class):
     @classmethod
     def setUpClass(cls):
         try:
-            startup(cls, cls.py_version, {'config_calibre_dir': TEST_DB}, work_path=CALIBRE_WEB_PATH,
-                    only_startup=True, only_metadata=True, env={"APP_MODE": "test"})
+            startup(cls, cls.py_version, {'config_calibre_dir': TEST_DB}, env={"APP_MODE": "test"})
             cls.login("admin", "admin123")
         except Exception:
             cls.driver.quit()
@@ -30,21 +29,15 @@ class TestCustomPages(TestCase, ui_class):
 
     @classmethod
     def tearDownClass(cls):
-        # cls.stop_calibre_web()
+        cls.driver.get("http://127.0.0.1:8083")
+        cls.stop_calibre_web()
         # close the browser window and stop calibre-web
         cls.driver.quit()
         cls.p.terminate()
         save_logfiles(cls, cls.__name__)
 
     def test_create_top_page(self):
-        admin_button = self.check_element_on_page((By.ID, "top_admin"))
-        self.assertTrue(admin_button)
-        # open admin screen
-        admin_button.click()
-        list_pages_button = self.check_element_on_page((By.ID, "list_pages"))
-        self.assertTrue(list_pages_button)
-        # open custom pages
-        list_pages_button.click()
+        self.goto_page('pages_config')
         new_page_button = self.check_element_on_page((By.ID, "new_page"))
         self.assertTrue(new_page_button)
         # create new page
@@ -58,7 +51,7 @@ class TestCustomPages(TestCase, ui_class):
         self.assertTrue(content_input)
         self.assertTrue(position_input)
         title_input.text = "Test Title"
-        name_input.text = "Test Name"
+        name_input.text = "Test Top"
         content_input.text = "## Test Heading\n\nTest Content"
         position_input.value = "1"
         submit_button = self.check_element_on_page((By.ID, "page_submit"))
@@ -66,22 +59,15 @@ class TestCustomPages(TestCase, ui_class):
         # submit new page
         submit_button.click()
         # check it was created
-        test_page = self.check_element_on_page((By.ID, "nav_Test Name"))
+        test_page = self.check_element_on_page((By.ID, "nav_Test Top"))
         self.assertTrue(test_page)
         side_nav = self.check_element_on_page((By.ID, "scnd-nav"))
         self.assertTrue(side_nav)
         children = side_nav.find_elements(By.XPATH, "*")
-        self.assertEqual(children[0].id, "nav_Test Name")
+        self.assertEqual(children[0].id, "nav_Test Top")
 
     def test_create_bottom_page(self):
-        admin_button = self.check_element_on_page((By.ID, "top_admin"))
-        self.assertTrue(admin_button)
-        # open admin screen
-        admin_button.click()
-        list_pages_button = self.check_element_on_page((By.ID, "list_pages"))
-        self.assertTrue(list_pages_button)
-        # open custom pages
-        list_pages_button.click()
+        self.goto_page('pages_config')
         new_page_button = self.check_element_on_page((By.ID, "new_page"))
         self.assertTrue(new_page_button)
         # create new page
@@ -95,7 +81,7 @@ class TestCustomPages(TestCase, ui_class):
         self.assertTrue(content_input)
         self.assertTrue(position_input)
         title_input.text = "Test Title"
-        name_input.text = "Test Name"
+        name_input.text = "Test Bottom"
         content_input.text = "## Test Heading\n\nTest Content"
         position_input.value = "0"
         submit_button = self.check_element_on_page((By.ID, "page_submit"))
@@ -103,9 +89,9 @@ class TestCustomPages(TestCase, ui_class):
         # submit new page
         submit_button.click()
         # check it was created
-        test_page = self.check_element_on_page((By.ID, "nav_Test Name"))
+        test_page = self.check_element_on_page((By.ID, "nav_Test Bottom"))
         self.assertTrue(test_page)
         side_nav = self.check_element_on_page((By.ID, "scnd-nav"))
         self.assertTrue(side_nav)
         children = side_nav.find_elements(By.XPATH, "*")
-        self.assertEqual(children[-1].id, "nav_Test Name")
+        self.assertEqual(children[-1].id, "nav_Test Bottom")

--- a/test/test_custom_pages.py
+++ b/test/test_custom_pages.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+from unittest import TestCase
+import os
+import time
+from unittest import skip
+from selenium.webdriver.common.by import By
+
+from helper_ui import ui_class
+from config_test import TEST_DB, CALIBRE_WEB_PATH
+from helper_func import startup
+from helper_func import save_logfiles
+
+
+class TestCustomPages(TestCase, ui_class):
+    p = None
+    driver = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            startup(cls, cls.py_version, {'config_calibre_dir': TEST_DB}, work_path=CALIBRE_WEB_PATH,
+                    only_startup=True, only_metadata=True, env={"APP_MODE": "test"})
+            cls.login("admin", "admin123")
+        except Exception:
+            cls.driver.quit()
+            cls.p.kill()
+
+    @classmethod
+    def tearDownClass(cls):
+        # cls.stop_calibre_web()
+        # close the browser window and stop calibre-web
+        cls.driver.quit()
+        cls.p.terminate()
+        save_logfiles(cls, cls.__name__)
+
+    def test_create_top_page(self):
+        admin_button = self.check_element_on_page((By.ID, "top_admin"))
+        self.assertTrue(admin_button)
+        # open admin screen
+        admin_button.click()
+        list_pages_button = self.check_element_on_page((By.ID, "list_pages"))
+        self.assertTrue(list_pages_button)
+        # open custom pages
+        list_pages_button.click()
+        new_page_button = self.check_element_on_page((By.ID, "new_page"))
+        self.assertTrue(new_page_button)
+        # create new page
+        new_page_button.click()
+        title_input = self.check_element_on_page((By.ID, "title"))
+        name_input = self.check_element_on_page((By.ID, "name"))
+        content_input = self.check_element_on_page((By.ID, "content"))
+        position_input = self.check_element_on_page((By.ID, "position"))
+        self.assertTrue(title_input)
+        self.assertTrue(name_input)
+        self.assertTrue(content_input)
+        self.assertTrue(position_input)
+        title_input.text = "Test Title"
+        name_input.text = "Test Name"
+        content_input.text = "## Test Heading\n\nTest Content"
+        position_input.value = "1"
+        submit_button = self.check_element_on_page((By.ID, "page_submit"))
+        self.assertTrue(submit_button)
+        # submit new page
+        submit_button.click()
+        # check it was created
+        test_page = self.check_element_on_page((By.ID, "nav_Test Name"))
+        self.assertTrue(test_page)
+        side_nav = self.check_element_on_page((By.ID, "scnd-nav"))
+        self.assertTrue(side_nav)
+        children = side_nav.find_elements(By.XPATH, "*")
+        self.assertEqual(children[0].id, "nav_Test Name")
+
+    def test_create_bottom_page(self):
+        admin_button = self.check_element_on_page((By.ID, "top_admin"))
+        self.assertTrue(admin_button)
+        # open admin screen
+        admin_button.click()
+        list_pages_button = self.check_element_on_page((By.ID, "list_pages"))
+        self.assertTrue(list_pages_button)
+        # open custom pages
+        list_pages_button.click()
+        new_page_button = self.check_element_on_page((By.ID, "new_page"))
+        self.assertTrue(new_page_button)
+        # create new page
+        new_page_button.click()
+        title_input = self.check_element_on_page((By.ID, "title"))
+        name_input = self.check_element_on_page((By.ID, "name"))
+        content_input = self.check_element_on_page((By.ID, "content"))
+        position_input = self.check_element_on_page((By.ID, "position"))
+        self.assertTrue(title_input)
+        self.assertTrue(name_input)
+        self.assertTrue(content_input)
+        self.assertTrue(position_input)
+        title_input.text = "Test Title"
+        name_input.text = "Test Name"
+        content_input.text = "## Test Heading\n\nTest Content"
+        position_input.value = "0"
+        submit_button = self.check_element_on_page((By.ID, "page_submit"))
+        self.assertTrue(submit_button)
+        # submit new page
+        submit_button.click()
+        # check it was created
+        test_page = self.check_element_on_page((By.ID, "nav_Test Name"))
+        self.assertTrue(test_page)
+        side_nav = self.check_element_on_page((By.ID, "scnd-nav"))
+        self.assertTrue(side_nav)
+        children = side_nav.find_elements(By.XPATH, "*")
+        self.assertEqual(children[-1].id, "nav_Test Name")


### PR DESCRIPTION
This is a companion PR for the [feature](https://github.com/janeczku/calibre-web/pull/2948)

Adds a page navigation sortcut for the custom pages admin configuration

Tests adding a custom page to the top and bottom of the navigation